### PR TITLE
Refactor highlighting to fix the double-unhighlight bug

### DIFF
--- a/arcscript.js
+++ b/arcscript.js
@@ -53,10 +53,6 @@ $(document).ready(function(){
 	var hzIInames = $(".character.horII");
 	var miscnames = $(".character.misc");
 
-	var intersections = $(".blue2, .orange2, .green2, .red2, .gold2, .purple2, .silver2, .black2");
-	var singleselect = $(".blue1, .orange1, .green1, .red1, .gold1, .purple1, .silver1, .black1");
-	var deselect = $(".blue, .orange, .green, .red, .gold, .purple, .silver, .black");
-
 	var allexposition = $("p");
 	var menus = $("div#nobilismenu, div#excrucianmenu, div#campaignmenu, div#toolmenu");
 
@@ -68,63 +64,33 @@ $(document).ready(function(){
 
 	clear.on("click", function(){
 		$(".highlight").removeClass("highlight");
-	  $(".pressed").removeClass("pressed");
-		$(".blue1").removeClass("blue1").addClass("blue");
-		$(".blue2").removeClass("blue2").addClass("blue");
-		$(".orange1").removeClass("orange1").addClass("orange");
-		$(".orange2").removeClass("orange2").addClass("orange");
-		$(".green1").removeClass("green1").addClass("green");
-		$(".green2").removeClass("green2").addClass("green");
-		$(".red1").removeClass("red1").addClass("red");
-		$(".red2").removeClass("red2").addClass("red");
-		$(".gold1").removeClass("gold1").addClass("gold");
-		$(".gold2").removeClass("gold2").addClass("gold");
-		$(".purple1").removeClass("purple1").addClass("purple");
-		$(".purple2").removeClass("purple2").addClass("purple");
-		$(".silver1").removeClass("silver1").addClass("silver");
-		$(".silver2").removeClass("silver2").addClass("silver");
-		$(".black1").removeClass("black1").addClass("black");
-		$(".black2").removeClass("black2").addClass("black");
-	  characters.hide();
+		$(".pressed").removeClass("pressed");
+
+		$(".highlighted1").data('highlighted', 0).removeClass('highlighted1 highlighted2 highlighted3 highlighted4');
+		characters.hide();
 		allexposition.hide();
 	});
 
 	function rotateOut(e){
-		if (e.hasClass("blue1")) e.removeClass("blue1").addClass("blue");
-		if (e.hasClass("blue2")) e.removeClass("blue2").addClass("blue1");
-		if (e.hasClass("orange1")) e.removeClass("orange1").addClass("orange");
-		if (e.hasClass("orange2")) e.removeClass("orange2").addClass("orange1");
-		if (e.hasClass("green1")) e.removeClass("green1").addClass("green");
-		if (e.hasClass("green2")) e.removeClass("green2").addClass("green1");
-		if (e.hasClass("red1")) e.removeClass("red1").addClass("red");
-		if (e.hasClass("red2")) e.removeClass("red2").addClass("red1");
-		if (e.hasClass("gold1")) e.removeClass("gold1").addClass("gold");
-		if (e.hasClass("gold2")) e.removeClass("gold2").addClass("gold1");
-		if (e.hasClass("purple1")) e.removeClass("purple1").addClass("purple");
-		if (e.hasClass("purple2")) e.removeClass("purple2").addClass("purple1");
-		if (e.hasClass("silver1")) e.removeClass("silver1").addClass("silver");
-		if (e.hasClass("silver2")) e.removeClass("silver2").addClass("silver1");
-		if (e.hasClass("black1")) e.removeClass("black1").addClass("black");
-		if (e.hasClass("black2")) e.removeClass("black2").addClass("black1");
+		let highlighted = e.data('highlighted') || 0;
+		highlighted -= 1;
+		e.data('highlighted', highlighted);
+
+		highlighted < 1 && e.removeClass('highlighted1');
+		highlighted < 2 && e.removeClass('highlighted2');
+		highlighted < 3 && e.removeClass('highlighted3');
+		highlighted < 4 && e.removeClass('highlighted4');
 	}
 
 	function rotateIn(e){
-		if (e.hasClass("blue1")) {e.removeClass("blue1").addClass("blue2");}
-		if (e.hasClass("blue")) e.removeClass("blue").addClass("blue1");
-		if (e.hasClass("orange1")) e.removeClass("orange1").addClass("orange2");
-		if (e.hasClass("orange")) e.removeClass("orange").addClass("orange1");
-		if (e.hasClass("green1")) e.removeClass("green1").addClass("green2");
-		if (e.hasClass("green")) e.removeClass("green").addClass("green1");
-		if (e.hasClass("red1")) {e.removeClass("red1").addClass("red2");}
-		if (e.hasClass("red")) {e.removeClass("red").addClass("red1");}
-		if (e.hasClass("gold1")) {e.removeClass("gold1").addClass("gold2");}
-		if (e.hasClass("gold")) {e.removeClass("gold").addClass("gold1");}
-		if (e.hasClass("purple1")) e.removeClass("purple1").addClass("purple2");
-		if (e.hasClass("purple")) e.removeClass("purple").addClass("purple1");
-		if (e.hasClass("silver1")) e.removeClass("silver1").addClass("silver2");
-		if (e.hasClass("silver")) e.removeClass("silver").addClass("silver1");
-		if (e.hasClass("black1")) {e.removeClass("black1").addClass("black2");}
-		if (e.hasClass("black")) {e.removeClass("black").addClass("black1");}
+		let highlighted = e.data('highlighted') || 0;
+		highlighted += 1;
+		e.data('highlighted', highlighted);
+
+		highlighted >= 1 && e.addClass('highlighted1');
+		highlighted >= 2 && e.addClass('highlighted2');
+		highlighted >= 3 && e.addClass('highlighted3');
+		highlighted >= 4 && e.addClass('highlighted4');
 	}
 
 	$(".nob").on("click", function(){
@@ -150,27 +116,21 @@ $(document).ready(function(){
 	});
 
 	$("#intersect").on("click", function(){
-		intersections = $(".blue2, .orange2, .green2, .red2, .gold2, .purple2, .silver2, .black2");
-		intersections.find(".character:not('.gmdnpc')").show();
+		$(".highlighted2").find(".character:not(.gmdnpc)").show();
 	});
 
 	$("#select").on("click", function(){
-		intersections = $(".blue2, .orange2, .green2, .red2, .gold2, .purple2, .silver2, .black2");
-		singleselect = $(".blue1, .orange1, .green1, .red1, .gold1, .purple1, .silver1, .black1");
-		intersections.find(".character:not('.gmdnpc')").show();
-		singleselect.find(".character:not('.gmdnpc')").show();
+		$(".highlighted1").find(".character:not(.gmdnpc)").show();
 	});
 
 	$("#deselect").on("click", function(){
-		singleselect = $(".blue1, .orange1, .green1, .red1, .gold1, .purple1, .silver1, .black1");
-		deselect = $(".blue, .orange, .green, .red, .gold, .purple, .silver, .black");
-		singleselect.find(".character").hide();
-		deselect.find(".character").hide();
+		let deselect = $(".blue, .orange, .green, .red, .gold, .purple, .silver, .black");
+		deselect.not(".highlighted2").find(".character").hide();
 	});
 
 	$("#fulldeselect").on("click", function(){
-		deselect = $(".blue, .orange, .green, .red, .gold, .purple, .silver, .black");
-		deselect.find(".character").hide();
+		let deselect = $(".blue, .orange, .green, .red, .gold, .purple, .silver, .black");
+		deselect.not(".highlighted1").find(".character").hide();
 	});
 
 	noblePCbox.on("click", function(){
@@ -560,97 +520,81 @@ $(document).ready(function(){
 
 	bluehead.on("click", function(){
 		if (bluehead.hasClass("highlight")) {
-			$(".blue1").removeClass("blue1").addClass("blue");
-			$(".blue2").removeClass("blue2").addClass("blue1");
+			$(".blue").each(function() { rotateOut($(this)) });
 			bluehead.removeClass("highlight");
 		}
 	  else {
-			$(".blue1").removeClass("blue1").addClass("blue2");
-			$(".blue").removeClass("blue").addClass("blue1");
+			$(".blue").each(function() { rotateIn($(this)) });
 			bluehead.addClass("highlight");
 		}
 	});
 	orahead.on("click", function(){
 		if (orahead.hasClass("highlight")) {
-			$(".orange1").removeClass("orange1").addClass("orange");
-			$(".orange2").removeClass("orange2").addClass("orange1");
+			$(".orange").each(function() { rotateOut($(this)) });
 			orahead.removeClass("highlight");
 		}
 	  else {
-			$(".orange1").removeClass("orange1").addClass("orange2");
-			$(".orange").removeClass("orange").addClass("orange1");
+			$(".orange").each(function() { rotateIn($(this)) });
 			orahead.addClass("highlight");
 		}
 	});
 	grehead.on("click", function(){
 		if (grehead.hasClass("highlight")) {
-			$(".green1").removeClass("green1").addClass("green");
-			$(".green2").removeClass("green2").addClass("green1");
+			$(".green").each(function() { rotateOut($(this)) });
 			grehead.removeClass("highlight");
 		}
 	  else {
-			$(".green1").removeClass("green1").addClass("green2");
-			$(".green").removeClass("green").addClass("green1");
+			$(".green").each(function() { rotateIn($(this)) });
 			grehead.addClass("highlight");
 		}
 	});
 	redhead.on("click", function(){
 		if (redhead.hasClass("highlight")) {
-			$(".red1").removeClass("red1").addClass("red");
-			$(".red2").removeClass("red2").addClass("red1");
+			$(".red").each(function() { rotateOut($(this)) });
 			redhead.removeClass("highlight");
 		}
 		else {
-			$(".red1").removeClass("red1").addClass("red2");
-			$(".red").removeClass("red").addClass("red1");
+			$(".red").each(function() { rotateIn($(this)) });
 			redhead.addClass("highlight");
 		}
 	});
 	goldhead.on("click", function(){
 		if (goldhead.hasClass("highlight")) {
-			$(".gold1").removeClass("gold1").addClass("gold");
-			$(".gold2").removeClass("gold2").addClass("gold1");
+			$(".gold").each(function() { rotateOut($(this)) });
 			goldhead.removeClass("highlight");
 		}
 		else {
-			$(".gold1").removeClass("gold1").addClass("gold2");
-			$(".gold").removeClass("gold").addClass("gold1");
+			$(".gold").each(function() { rotateIn($(this)) });
 			goldhead.addClass("highlight");
 		}
 	});
 	purphead.on("click", function(){
 		if (purphead.hasClass("highlight")) {
-			$(".purple1").removeClass("purple1").addClass("purple");
-			$(".purple2").removeClass("purple2").addClass("purple1");
+			$(".purple").each(function() { rotateOut($(this)) });
 			purphead.removeClass("highlight");
 		}
 		else {
-			$(".purple1").removeClass("purple1").addClass("purple2");
-			$(".purple").removeClass("purple").addClass("purple1");
+			$(".purple").each(function() { rotateIn($(this)) });
 			purphead.addClass("highlight");
 		}
 	});
 	silhead.on("click", function(){
 		if (silhead.hasClass("highlight")) {
-			$(".silver1").removeClass("silver1").addClass("silver");
-			$(".silver2").removeClass("silver2").addClass("silver1");
+			$(".silver").each(function() { rotateOut($(this)) });
 			silhead.removeClass("highlight");
 		}
 		else {
-			$(".silver1").removeClass("silver1").addClass("silver2");
-			$(".silver").removeClass("silver").addClass("silver1");
+			$(".silver").each(function() { rotateIn($(this)) });
 			silhead.addClass("highlight");
 		}
 	});
 	blkhead.on("click", function(){
 		if (blkhead.hasClass("highlight")) {
-			$(".black1").removeClass("black1").addClass("black");
-			$(".black2").removeClass("black2").addClass("black1");
+			$(".black").each(function() { rotateOut($(this)) });
 			blkhead.removeClass("highlight");
 		}
 		else {
-			$(".black1").removeClass("black1").addClass("black2");
-			$(".black").removeClass("black").addClass("black1");
+			$(".black").each(function() { rotateIn($(this)) });
 			blkhead.addClass("highlight");
 		}
 	});

--- a/arcstyle.css
+++ b/arcstyle.css
@@ -79,276 +79,132 @@ td{
   background-color: #adadad;
 }
 
+.blue, .orange, .green, .red, .gold, .purple, .silver, .black {
+  padding: 7px;
+  background-color: var(--bg-color);
+}
+
+.immortal {
+  --highlight: #fffacd;
+}
+
+.frantic {
+  --highlight: #aab7b7;
+}
+
+.sickly {
+  --highlight: black;
+}
+
 .blue {
   color: #aaaaaa;
-  background-color: #0B1675;
-  padding: 7px;
+  --bg-color: #0B1675;
 }
-.blue.highlighted1{
-  background-color: #1C3696;
-  border: 3px solid;
-  padding: 4px;
+.blue.highlighted1 {
+  --bg-color: #1C3696;
 }
-.blue.highlighted2{
-  background-color: #1F50A5;
-  border: 6px double;
-}
-.blue.highlighted3 {
-  box-shadow:
-    2px 2px #1F50A5 inset,
-    -2px -2px #1F50A5 inset,
-    -4px -4px #aaaaaa inset,
-    4px 4px #aaaaaa inset;
-}
-.blue.highlighted4 {
-  box-shadow:
-    2px 2px #1F50A5 inset,
-    -2px -2px #1F50A5 inset,
-    -4px -4px #aaaaaa inset,
-    4px 4px #aaaaaa inset,
-    6px 6px #1F50A5 inset,
-    -6px -6px #1F50A5 inset,
-    -8px -8px #aaaaaa inset,
-    8px 8px #aaaaaa inset;
+.blue.highlighted2 {
+  --bg-color: #1F50A5;
 }
 
 .orange {
-  background-color: #DA6E21;
-  padding: 7px;
+  --bg-color: #DA6E21;
 }
 .orange.highlighted1 {
-  background-color: #DA853A;
-  border: 3px solid;
-  padding: 4px;
+  --bg-color: #DA853A;
 }
 .orange.highlighted2 {
-  background-color: #E09834;
-  border: 6px double;
-}
-.orange.highlighted3 {
-  box-shadow:
-    2px 2px #E09834 inset,
-    -2px -2px #E09834 inset,
-    -4px -4px black inset,
-    4px 4px black inset;
-}
-.orange.highlighted4 {
-  box-shadow:
-    2px 2px #E09834 inset,
-    -2px -2px #E09834 inset,
-    -4px -4px black inset,
-    4px 4px black inset,
-    6px 6px #E09834 inset,
-    -6px -6px #E09834 inset,
-    -8px -8px black inset,
-    8px 8px black inset;
+  --bg-color: #E09834;
 }
 
 .green {
-  background-color: #016923;
-  padding: 7px;
+  --bg-color: #016923;
 }
 .green.highlighted1 {
-  background-color: #018D32;
-  border: 3px solid;
-  padding: 4px;
+  --bg-color: #018D32;
 }
 .green.highlighted2 {
-  background-color: #009E3A;
-  border: 6px double;
-}
-.green.highlighted3 {
-  box-shadow:
-    2px 2px #009E3A inset,
-    -2px -2px #009E3A inset,
-    -4px -4px black inset,
-    4px 4px black inset;
-}
-.green.highlighted4 {
-  box-shadow:
-    2px 2px #009E3A inset,
-    -2px -2px #009E3A inset,
-    -4px -4px black inset,
-    4px 4px black inset,
-    6px 6px #009E3A inset,
-    -6px -6px #009E3A inset,
-    -8px -8px black inset,
-    8px 8px black inset;
+  --bg-color: #009E3A;
 }
 
 .red {
   color: #aaaaaa;
-  background-color: #6B0200;
-  padding: 7px;
+  --bg-color: #6B0200;
 }
 .red.highlighted1 {
-  background-color: #911411;
-  border: 3px solid;
-  padding: 4px;
+  --bg-color: #911411;
 }
 .red.highlighted2 {
-  background-color: #B03E43;
-  border: 6px double;
-}
-.red.highlighted3 {
-  box-shadow:
-    2px 2px #B03E43 inset,
-    -2px -2px #B03E43 inset,
-    -4px -4px #aaa inset,
-    4px 4px #aaa inset;
-}
-.red.highlighted4 {
-  box-shadow:
-    2px 2px #B03E43 inset,
-    -2px -2px #B03E43 inset,
-    -4px -4px #aaa inset,
-    4px 4px #aaa inset,
-    6px 6px #B03E43 inset,
-    -6px -6px #B03E43 inset,
-    -8px -8px #aaa inset,
-    8px 8px #aaa inset;
+  --bg-color: #B03E43;
 }
 
 .gold {
-  background-color: #F9AE19;
-  padding: 7px;
+  --bg-color: #F9AE19;
 }
 .gold.highlighted1 {
-  background-color: #FFC023;
-  border: 3px solid;
-  padding: 4px;
+  --bg-color: #FFC023;
 }
 .gold.highlighted2 {
-  background-color: #FFE261;
-  border: 6px double;
-}
-.gold.highlighted3 {
-  box-shadow:
-    2px 2px #FFE261 inset,
-    -2px -2px #FFE261 inset,
-    -4px -4px black inset,
-    4px 4px black inset;
-}
-.gold.highlighted4 {
-  box-shadow:
-    2px 2px #FFE261 inset,
-    -2px -2px #FFE261 inset,
-    -4px -4px black inset,
-    4px 4px black inset,
-    6px 6px #FFE261 inset,
-    -6px -6px #FFE261 inset,
-    -8px -8px black inset,
-    8px 8px black inset;
+  --bg-color: #FFE261;
 }
 
 .purple {
   color: #aaaaaa;
-  background-color: #540B75;
-  padding: 7px;
+  --bg-color: #540B75;
 }
 .purple.highlighted1 {
-  background-color: #5C2182;
-  border: 3px solid;
-  padding: 4px;
+  --bg-color: #5C2182;
 }
 .purple.highlighted2 {
-  background-color: #782C91;
-  border: 6px double;
-}
-.purple.highlighted3 {
-  box-shadow:
-    2px 2px #782C91 inset,
-    -2px -2px #782C91 inset,
-    -4px -4px #aaa inset,
-    4px 4px #aaa inset;
-}
-.purple.highlighted4 {
-  box-shadow:
-    2px 2px #782C91 inset,
-    -2px -2px #782C91 inset,
-    -4px -4px #aaa inset,
-    4px 4px #aaa inset,
-    6px 6px #782C91 inset,
-    -6px -6px #782C91 inset,
-    -8px -8px #aaa inset,
-    8px 8px #aaa inset;
+  --bg-color: #782C91;
 }
 
-.silver{
-  background-color: #5E5B6E;
-  padding: 7px;
+.silver {
+  --bg-color: #5E5B6E;
 }
 .silver.highlighted1 {
-  background-color: #726E85;
-  border: 3px solid;
-  padding: 4px;
+  --bg-color: #726E85;
 }
 .silver.highlighted2 {
-  background-color: #8D8BA1;
-  border: 6px double;
-  padding: 4px;
-}
-.silver.highlighted3 {
-  box-shadow:
-    2px 2px #8D8BA1 inset,
-    -2px -2px #8D8BA1 inset,
-    -4px -4px black inset,
-    4px 4px black inset;
-}
-.silver.highlighted4 {
-  box-shadow:
-    2px 2px #8D8BA1 inset,
-    -2px -2px #8D8BA1 inset,
-    -4px -4px black inset,
-    4px 4px black inset,
-    6px 6px #8D8BA1 inset,
-    -6px -6px #8D8BA1 inset,
-    -8px -8px black inset,
-    8px 8px black inset;
+  --bg-color: #8D8BA1;
 }
 
-.black{
-  background-color: #201C35;
+.black {
   color: #aaaaaa;
-  padding: 7px;
+  --bg-color: #201C35;
 }
-.black.highlighted1{
-  background-color: #26263B;
-  border: 3px solid;
+.black.highlighted1 {
+  --bg-color: #26263B;
+}
+.black.highlighted2 {
+  --bg-color: #313143;
+}
+
+.highlighted1 {
+  border: 3px solid var(--highlight);
   padding: 4px;
 }
-.black.highlighted2{
-  background-color: #313143;
-  border: 6px double;
+
+.highlighted2 {
+  border: 6px double var(--highlight);
+  padding: 0;
 }
-.black.highlighted3 {
+
+.highlighted3 {
   box-shadow:
-    2px 2px #313143 inset,
-    -2px -2px #313143 inset,
-    -4px -4px #aaa inset,
-    4px 4px #aaa inset;
+    2px 2px var(--bg-color) inset,
+    -2px -2px var(--bg-color) inset,
+    -4px -4px var(--highlight) inset,
+    4px 4px var(--highlight) inset;
 }
-.black.highlighted4 {
+.highlighted4 {
   box-shadow:
-    2px 2px #313143 inset,
-    -2px -2px #313143 inset,
-    -4px -4px #aaa inset,
-    4px 4px #aaa inset,
-    6px 6px #313143 inset,
-    -6px -6px #313143 inset,
-    -8px -8px #aaa inset,
-    8px 8px #aaa inset;
-}
-
-
-.immortal {
-  border-color: #fffacd;
-}
-
-.frantic{
-  border-color: #aab7b7;
-}
-
-.sickly {
-  border-color: black;
+    2px 2px var(--bg-color) inset,
+    -2px -2px var(--bg-color) inset,
+    -4px -4px var(--highlight) inset,
+    4px 4px var(--highlight) inset,
+    6px 6px var(--bg-color) inset,
+    -6px -6px var(--bg-color) inset,
+    -8px -8px var(--highlight) inset,
+    8px 8px var(--highlight) inset;
 }

--- a/arcstyle.css
+++ b/arcstyle.css
@@ -84,117 +84,260 @@ td{
   background-color: #0B1675;
   padding: 7px;
 }
-.blue1{
-  color: #aaaaaa;
+.blue.highlighted1{
   background-color: #1C3696;
   border: 3px solid;
   padding: 4px;
 }
-.blue2{
-  color: #aaaaaa;
+.blue.highlighted2{
   background-color: #1F50A5;
   border: 6px double;
 }
+.blue.highlighted3 {
+  box-shadow:
+    2px 2px #1F50A5 inset,
+    -2px -2px #1F50A5 inset,
+    -4px -4px #aaaaaa inset,
+    4px 4px #aaaaaa inset;
+}
+.blue.highlighted4 {
+  box-shadow:
+    2px 2px #1F50A5 inset,
+    -2px -2px #1F50A5 inset,
+    -4px -4px #aaaaaa inset,
+    4px 4px #aaaaaa inset,
+    6px 6px #1F50A5 inset,
+    -6px -6px #1F50A5 inset,
+    -8px -8px #aaaaaa inset,
+    8px 8px #aaaaaa inset;
+}
+
 .orange {
   background-color: #DA6E21;
   padding: 7px;
 }
-.orange1 {
+.orange.highlighted1 {
   background-color: #DA853A;
   border: 3px solid;
   padding: 4px;
 }
-.orange2 {
+.orange.highlighted2 {
   background-color: #E09834;
   border: 6px double;
 }
+.orange.highlighted3 {
+  box-shadow:
+    2px 2px #E09834 inset,
+    -2px -2px #E09834 inset,
+    -4px -4px black inset,
+    4px 4px black inset;
+}
+.orange.highlighted4 {
+  box-shadow:
+    2px 2px #E09834 inset,
+    -2px -2px #E09834 inset,
+    -4px -4px black inset,
+    4px 4px black inset,
+    6px 6px #E09834 inset,
+    -6px -6px #E09834 inset,
+    -8px -8px black inset,
+    8px 8px black inset;
+}
+
 .green {
   background-color: #016923;
   padding: 7px;
 }
-.green1 {
+.green.highlighted1 {
   background-color: #018D32;
   border: 3px solid;
   padding: 4px;
 }
-.green2 {
+.green.highlighted2 {
   background-color: #009E3A;
   border: 6px double;
 }
+.green.highlighted3 {
+  box-shadow:
+    2px 2px #009E3A inset,
+    -2px -2px #009E3A inset,
+    -4px -4px black inset,
+    4px 4px black inset;
+}
+.green.highlighted4 {
+  box-shadow:
+    2px 2px #009E3A inset,
+    -2px -2px #009E3A inset,
+    -4px -4px black inset,
+    4px 4px black inset,
+    6px 6px #009E3A inset,
+    -6px -6px #009E3A inset,
+    -8px -8px black inset,
+    8px 8px black inset;
+}
+
 .red {
   color: #aaaaaa;
   background-color: #6B0200;
   padding: 7px;
 }
-.red1 {
-  color: #aaaaaa;
+.red.highlighted1 {
   background-color: #911411;
   border: 3px solid;
   padding: 4px;
 }
-.red2 {
-  color: #aaaaaa;
+.red.highlighted2 {
   background-color: #B03E43;
   border: 6px double;
 }
+.red.highlighted3 {
+  box-shadow:
+    2px 2px #B03E43 inset,
+    -2px -2px #B03E43 inset,
+    -4px -4px #aaa inset,
+    4px 4px #aaa inset;
+}
+.red.highlighted4 {
+  box-shadow:
+    2px 2px #B03E43 inset,
+    -2px -2px #B03E43 inset,
+    -4px -4px #aaa inset,
+    4px 4px #aaa inset,
+    6px 6px #B03E43 inset,
+    -6px -6px #B03E43 inset,
+    -8px -8px #aaa inset,
+    8px 8px #aaa inset;
+}
+
 .gold {
   background-color: #F9AE19;
   padding: 7px;
 }
-.gold1 {
+.gold.highlighted1 {
   background-color: #FFC023;
   border: 3px solid;
   padding: 4px;
 }
-.gold2 {
+.gold.highlighted2 {
   background-color: #FFE261;
   border: 6px double;
 }
+.gold.highlighted3 {
+  box-shadow:
+    2px 2px #FFE261 inset,
+    -2px -2px #FFE261 inset,
+    -4px -4px black inset,
+    4px 4px black inset;
+}
+.gold.highlighted4 {
+  box-shadow:
+    2px 2px #FFE261 inset,
+    -2px -2px #FFE261 inset,
+    -4px -4px black inset,
+    4px 4px black inset,
+    6px 6px #FFE261 inset,
+    -6px -6px #FFE261 inset,
+    -8px -8px black inset,
+    8px 8px black inset;
+}
+
 .purple {
   color: #aaaaaa;
   background-color: #540B75;
   padding: 7px;
 }
-.purple1 {
-  color: #aaaaaa;
+.purple.highlighted1 {
   background-color: #5C2182;
   border: 3px solid;
   padding: 4px;
 }
-.purple2 {
-  color: #aaaaaa;
+.purple.highlighted2 {
   background-color: #782C91;
   border: 6px double;
 }
+.purple.highlighted3 {
+  box-shadow:
+    2px 2px #782C91 inset,
+    -2px -2px #782C91 inset,
+    -4px -4px #aaa inset,
+    4px 4px #aaa inset;
+}
+.purple.highlighted4 {
+  box-shadow:
+    2px 2px #782C91 inset,
+    -2px -2px #782C91 inset,
+    -4px -4px #aaa inset,
+    4px 4px #aaa inset,
+    6px 6px #782C91 inset,
+    -6px -6px #782C91 inset,
+    -8px -8px #aaa inset,
+    8px 8px #aaa inset;
+}
+
 .silver{
   background-color: #5E5B6E;
   padding: 7px;
 }
-.silver1 {
+.silver.highlighted1 {
   background-color: #726E85;
   border: 3px solid;
   padding: 4px;
 }
-.silver2 {
+.silver.highlighted2 {
   background-color: #8D8BA1;
   border: 6px double;
   padding: 4px;
 }
+.silver.highlighted3 {
+  box-shadow:
+    2px 2px #8D8BA1 inset,
+    -2px -2px #8D8BA1 inset,
+    -4px -4px black inset,
+    4px 4px black inset;
+}
+.silver.highlighted4 {
+  box-shadow:
+    2px 2px #8D8BA1 inset,
+    -2px -2px #8D8BA1 inset,
+    -4px -4px black inset,
+    4px 4px black inset,
+    6px 6px #8D8BA1 inset,
+    -6px -6px #8D8BA1 inset,
+    -8px -8px black inset,
+    8px 8px black inset;
+}
+
 .black{
   background-color: #201C35;
   color: #aaaaaa;
   padding: 7px;
 }
-.black1{
+.black.highlighted1{
   background-color: #26263B;
-  color: #aaaaaa;
   border: 3px solid;
   padding: 4px;
 }
-.black2{
+.black.highlighted2{
   background-color: #313143;
-  color: #aaaaaa;
   border: 6px double;
+}
+.black.highlighted3 {
+  box-shadow:
+    2px 2px #313143 inset,
+    -2px -2px #313143 inset,
+    -4px -4px #aaa inset,
+    4px 4px #aaa inset;
+}
+.black.highlighted4 {
+  box-shadow:
+    2px 2px #313143 inset,
+    -2px -2px #313143 inset,
+    -4px -4px #aaa inset,
+    4px 4px #aaa inset,
+    6px 6px #313143 inset,
+    -6px -6px #313143 inset,
+    -8px -8px #aaa inset,
+    8px 8px #aaa inset;
 }
 
 


### PR DESCRIPTION
On the current version of the page, there's a bug where if you highlight three different factions that all share an arc, and then unhighlight two of them, the page "forgets" the most-highlighted arc. 

For example:

 1. highlight Angels, Magisters of the Light, and Zu
 2. un-highlight Zu and Magisters of the Light
 3. see that only 3 arcs are highlighted, and CotL is un-highlighted

To fix this problem, i store a `highlighted` data variable on each element that counts how many times that element has been highlighted. I then use that variable to apply CSS classes. This has the side-effect of making a lot of the code cleaner and easier to read—everything that has been highlighted at least once has `.highlighted1`, everything that has been highlighted at least twice has `.highlighted2`, etc. Because these classes are no longer based on the color names, they're much easier to query and update.