### PR TITLE
Fix links to match Tumblr's spaces in tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
             <div class="character miscname">
             <br><b>Leonardo de Montreal</b><br>Angel of Recovery</div>
           </td>
-          <td class="frantic orange actual gmdnpc gmdpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/become-somebody/chrono"><span class ="arcName">Become Somebody</span><span class ="attrName">Visage</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="frantic orange actual gmdnpc gmdpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/become%20somebody/chrono"><span class ="arcName">Become Somebody</span><span class ="attrName">Visage</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Seizhi Schwan</b><br>The Best Friend</div>
             <div class="character gmdnpcname">
@@ -122,7 +122,7 @@
             <div class="character gmdnpcname">
             <br><b>Nikolai Zakharov</b></div>
           </td>
-          <td class="sickly orange deceiver attr wild zu horI horII"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/knave-of-hearts/chrono"><span class ="arcName">Star Quality</span><span class ="attrName">Persona</span></a><span class="draft"><br>Draft, formerly Frantic Mystic: Knave of Hearts</span>
+          <td class="sickly orange deceiver attr wild zu horI horII"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/knave%20of%20hearts/chrono"><span class ="arcName">Star Quality</span><span class ="attrName">Persona</span></a><span class="draft"><br>Draft, formerly Frantic Mystic: Knave of Hearts</span>
             <div class="character horIname">
             <br><b>Jasmine Apocynum</b><br>The Ideologue</div>
             <div class="character horIIname">
@@ -132,7 +132,7 @@
 
          <tr>
           <th class="green header">Green<br>Otherworldly</th>
-          <td class="immortal green serpent true gmdpc gmdnpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/child-of-the-ash/chrono"><span class ="arcName">Child of the Ash</span><span class ="attrName">Vastness</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="immortal green serpent true gmdpc gmdnpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/child%20of%20the%20ash/chrono"><span class ="arcName">Child of the Ash</span><span class ="attrName">Vastness</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Chuubo</b><br>The Wishing Boy</div>
             <div class="character gmdpcname">
@@ -172,7 +172,7 @@
 
         <tr>
           <th class="red header">Red<br>Storyteller</th>
-          <td class="immortal red angel rule devil zu gmdpc horII gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/creature-of-the-light/chrono"><span class ="arcName">Creature of the Light</span><span class ="attrName">Holy</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="immortal red angel rule devil zu gmdpc horII gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/creature%20of%20the%20light/chrono"><span class ="arcName">Creature of the Light</span><span class ="attrName">Holy</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Entropy II</b><br>The Angel of Fortitude</div>
             <div class="character horIIname">
@@ -187,7 +187,7 @@
             <br><b>Unicorn</b><br>named Numinous</div>
           </td>
 
-          <td class="frantic red warmain game gmdpc horI horII gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/creature-of-fable/chrono"><span class ="arcName">Creature of Fable</span><span class ="attrName">Hunter</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="frantic red warmain game gmdpc horI horII gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/creature%20of%20fable/chrono"><span class ="arcName">Creature of Fable</span><span class ="attrName">Hunter</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Rinley Yatskaya</b><br>The Troublemaker</div>
             <div class="character horIname">
@@ -213,19 +213,19 @@
         </tr>
         <tr>
           <th class="gold header">Yellow<br>Aspect</th>
-            <td class="immortal gold angel zu misc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/magical-hero/chrono"><span class ="arcName">Chosen One</span><span class ="attrName">Adept</span></a><span class="draft"><br>Draft, formerly Magical Hero</span>
+            <td class="immortal gold angel zu misc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/magical%20hero/chrono"><span class ="arcName">Chosen One</span><span class ="attrName">Adept</span></a><span class="draft"><br>Draft, formerly Magical Hero</span>
             <div class="character miscname">
             <br><b>Jade Irinka</b><br>Angel of the Houses of the Sun</div>
           </td>
 
-          <td class="frantic gold zu attr gmdpc gmdnpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/the-ace/chrono"><span class ="arcName">The Ace</span><span class ="attrName">Aspect</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="frantic gold zu attr gmdpc gmdnpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/the%20ace/chrono"><span class ="arcName">The Ace</span><span class ="attrName">Aspect</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Natalia Koutolika</b><br>The Prodigy</div>
             <div class="character gmdnpcname">
             <br><b>Melanie Malakh</b></div>
           </td>
 
-          <td class="sickly gold deceiver devil serpent gmdpc gmdnpc horI horII"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/reality-syndrome/chrono"><span class ="arcName">Reality Syndrome</span><span class ="attrName">Sealed</span></a><span class="draft"><br>Published in CMWGE core, formerly Sickly Knight</span>
+          <td class="sickly gold deceiver devil serpent gmdpc gmdnpc horI horII"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/reality%20syndrome/chrono"><span class ="arcName">Reality Syndrome</span><span class ="attrName">Sealed</span></a><span class="draft"><br>Published in CMWGE core, formerly Sickly Knight</span>
             <div class="character horIname gmdpcname">
             <br><b>Chuubo</b><br>The Wishing Boy</div>
             <div class="character gmdnpcname">
@@ -245,7 +245,7 @@
         <tr>
           <th class="purple header">Purple<br>Shepherd</th>
 
-          <td class="immortal purple angel rule gmdpc gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/a-keeper-of-gardens/chrono"><span class ="arcName">A Keeper of Gardens</span><span class ="attrName">Gardener</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="immortal purple angel rule gmdpc gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/a%20keeper%20of%20gardens/chrono"><span class ="arcName">A Keeper of Gardens</span><span class ="attrName">Gardener</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Entropy II</b><br>The Angel of Fortitude</div>
             <div class="character gmdnpcname">
@@ -273,7 +273,7 @@
             <br><b>Melanie Malakh</b></div>
           </td>
 
-          <td class="sickly purple actual warmain rule horI horII"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/sickly-storyteller/chrono"><span class ="arcName">Impresario</span><span class ="attrName">Architect</span></a><span class="draft"><br>Draft, formerly Sickly Storyteller: Self-Made</span>
+          <td class="sickly purple actual warmain rule horI horII"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/sickly%20storyteller/chrono"><span class ="arcName">Impresario</span><span class ="attrName">Architect</span></a><span class="draft"><br>Draft, formerly Sickly Storyteller: Self-Made</span>
             <div class="character horIname">
             <br><b>Soun Shounen</b><br>The Idol</div>
             <div class="character horIIname">
@@ -292,7 +292,7 @@
           <td class="frantic silver mimic strategist mimic"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/renegade/chrono"><span class ="arcName">Troubled</span><span class ="attrName">Eide</span></a><span class="draft"><br>Draft, formerly Frantic Bindings: Renegade</span>
             </td>
 
-          <td class="sickly silver strategist gmdpc horI gmdnpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/sickly-silver/chrono"><span class ="arcName">Accursed</span><span class ="attrName">Wyrd</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="sickly silver strategist gmdpc horI gmdnpc"><a class="lightbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/sickly%20silver/chrono"><span class ="arcName">Accursed</span><span class ="attrName">Wyrd</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Miramie Mesmer</b><br>The Dream-Witch</div>
             <div class="character horIname">

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
             <br><b>Laodemus Schwan</b><br>The Wish-Granting Engine</div>
           </td>
 
-          <td class="sickly blue mimic devil gmdpc gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/wounded-angel/chrono"><span class ="arcName">Wounded Angel</span><span class ="attrName">Wounded</span></a><span class="draft"><br>Published in CMWGE core</span>
+          <td class="sickly blue mimic devil gmdpc gmdnpc"><a class="darkbg" target="_blank" href="http://jennamoran.tumblr.com/tagged/wounded%20angel/chrono"><span class ="arcName">Wounded Angel</span><span class ="attrName">Wounded</span></a><span class="draft"><br>Published in CMWGE core</span>
             <div class="character gmdpcname">
             <br><b>Leonardo de Montreal</b><br>Nightmares' Angel</div>
             <div class="character gmdnpcname">


### PR DESCRIPTION
As discussed on the Discord, Tumblr changed how they handled spaces in tags. Because of this, several existing links were to 404s.